### PR TITLE
Update to work with new playback API in Mopidy 1.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,8 @@ v1.0.0 (UNRELEASED)
 
 - Update to work with new playback API in Mopidy 1.0
 
+- Update to work with new search API in Mopidy 1.0
+
 v0.3.1 (2014-01-28)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,8 @@ v1.0.0 (UNRELEASED)
 
 - Require Mopidy >= 1.0
 
+- Update to work with new playback API in Mopidy 1.0
+
 v0.3.1 (2014-01-28)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,13 @@ Project resources
 Changelog
 =========
 
+v1.0.0 (UNRELEASED)
+-------------------
+
+- Require Mopidy >= 1.0
+
 v0.3.1 (2014-01-28)
------------------
+-------------------
 
 - Removed last_modified field from Playlist generation, to avoid problem in Mopidy core
 

--- a/mopidy_subsonic/__init__.py
+++ b/mopidy_subsonic/__init__.py
@@ -4,7 +4,7 @@ import os
 
 from mopidy import ext, config
 
-__version__ = '0.3.1'
+__version__ = '1.0.0'
 
 
 class SubsonicExtension(ext.Extension):

--- a/mopidy_subsonic/actor.py
+++ b/mopidy_subsonic/actor.py
@@ -9,7 +9,6 @@ from .library import SubsonicLibraryProvider
 from .playlist import SubsonicPlaylistsProvider
 from .client import SubsonicRemoteClient
 
-from mopidy.models import Track
 
 logger = logging.getLogger(__name__)
 
@@ -37,18 +36,8 @@ class SubsonicBackend(pykka.ThreadingActor, backend.Backend):
 
 class SubsonicPlaybackProvider(backend.PlaybackProvider):
 
-    def play(self, track):
-        logger.debug('Getting info for track %s' % (track.name))
-        id = track.uri.split("subsonic://")[1]
+    def translate_uri(self, uri):
+        logger.debug('Getting info for track %s' % uri)
+        id = uri.split('subsonic://')[1]
         real_uri = self.backend.remote.build_url_from_song_id(id)
-        ntrack = Track(
-            uri=real_uri,
-            name=track.name,
-            artists=track.artists,
-            album=track.album,
-            track_no=track.track_no,
-            disc_no=track.disc_no,
-            date=track.date,
-            length=track.length,
-            bitrate=track.bitrate)
-        return super(SubsonicPlaybackProvider, self).play(ntrack)
+        return real_uri

--- a/mopidy_subsonic/library.py
+++ b/mopidy_subsonic/library.py
@@ -14,7 +14,7 @@ class SubsonicLibraryProvider(backend.LibraryProvider):
         super(SubsonicLibraryProvider, self).__init__(*args, **kwargs)
         self.remote = self.backend.remote
 
-    def find_exact(self, query=None, uris=None):
+    def _find_exact(self, query=None, uris=None):
         if not query:
             # Fetch all artists(browse library)
             return SearchResult(
@@ -26,7 +26,10 @@ class SubsonicLibraryProvider(backend.LibraryProvider):
             tracks=self.remote.get_tracks_by(
                 query.get('artist'), query.get('album')))
 
-    def search(self, query=None, uris=None):
+    def search(self, query=None, uris=None, exact=False):
+        if exact:
+            return self._find_exact(query=query, uris=uris)
+
         logger.debug('Query "%s":' % query)
 
         artist, album, title, any = None, None, None, None

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'setuptools',
-        'Mopidy >= 0.18',
+        'Mopidy >= 1.0',
         'Pykka >= 1.1',
         'py-sonic',
     ],


### PR DESCRIPTION
Mopidy is soon ready for its 1.0 release. In 1.0 we've broken the backend playback API to make it possible to ship gapless playback in Mopidy 1.1. Without this update, Mopidy-Subsonic will not work with Mopidy >= 1.0.