### PR TITLE
context optional and year to string.

### DIFF
--- a/mopidy_subsonic/__init__.py
+++ b/mopidy_subsonic/__init__.py
@@ -24,7 +24,7 @@ class SubsonicExtension(ext.Extension):
         schema['username'] = config.String()
         schema['password'] = config.Secret()
         schema['ssl'] = config.Boolean()
-        schema['context'] = config.String()
+        schema['context'] = config.String(optional=True)
         return schema
 
     def setup(self, registry):

--- a/mopidy_subsonic/client.py
+++ b/mopidy_subsonic/client.py
@@ -250,7 +250,7 @@ class SubsonicRemoteClient(object):
             track_kwargs['name'] = data['title']
 
         if 'year' in data:
-            track_kwargs['date'] = data['year']
+            track_kwargs['date'] = str(data['year'])
         else:
             track_kwargs['date'] = 'none'
 


### PR DESCRIPTION
context should be optional because you can end up with a url that looks like `my.subsonic.server/False/rest` or `my.subsonic.server/''/rest` and mopidy itself will complain if you don't set it since it is not optional currently.

I suppose this is a duplicate of #19 but I think offering it as an option feels nice in general.

then a fix to client to force `data['year']` to a string which is basically #18.