### PR TITLE
Add support for legacy auth option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ following to your Mopidy configuration::
     password = PASS
     ssl = (yes/no)
     context = my-subsonic (if your subsonic is accessible on http://some.website.com:8888/my-subsonic/index.view)
+    legacy_auth = (yes/no. optional, default is no. Setting to yes uses legacy auth, which may fix auth errors when connecting to subsonic-compatible APIs)
 
 Searches in Mopidy will now return results from your Subsonic library.
 

--- a/mopidy_subsonic/__init__.py
+++ b/mopidy_subsonic/__init__.py
@@ -25,6 +25,7 @@ class SubsonicExtension(ext.Extension):
         schema['password'] = config.Secret()
         schema['ssl'] = config.Boolean()
         schema['context'] = config.String()
+        schema['legacy_auth'] = config.Boolean()
         return schema
 
     def setup(self, registry):

--- a/mopidy_subsonic/actor.py
+++ b/mopidy_subsonic/actor.py
@@ -24,7 +24,8 @@ class SubsonicBackend(pykka.ThreadingActor, backend.Backend):
             config['subsonic']['username'],
             config['subsonic']['password'],
             config['subsonic']['ssl'],
-            config['subsonic']['context'])
+            config['subsonic']['context'],
+            config['subsonic']['legacy_auth'])
 
         self.config = config
         self.library = SubsonicLibraryProvider(backend=self)

--- a/mopidy_subsonic/client.py
+++ b/mopidy_subsonic/client.py
@@ -99,7 +99,7 @@ class cache(object):
 
 class SubsonicRemoteClient(object):
 
-    def __init__(self, hostname, port, username, password, ssl, context):
+    def __init__(self, hostname, port, username, password, ssl, context, legacy_auth):
         super(SubsonicRemoteClient, self).__init__()
 
         if not (hostname and port and username and password):
@@ -118,7 +118,7 @@ class SubsonicRemoteClient(object):
             else:
                 self.api_context = "/rest"
 
-            self.api = libsonic.Connection(self.api_hostname, self.api_user, self.api_pass, port=int(self.api_port), serverPath=self.api_context)
+            self.api = libsonic.Connection(self.api_hostname, self.api_user, self.api_pass, port=int(self.api_port), serverPath=self.api_context, legacyAuth=legacy_auth)
             logger.info('Connecting to Subsonic library %s:%s as user %s', self.api_hostname, self.api_port, self.api_user)
             try:
                 self.api.ping()

--- a/mopidy_subsonic/ext.conf
+++ b/mopidy_subsonic/ext.conf
@@ -6,3 +6,4 @@ username =
 password = 
 ssl = 
 context = 
+legacy_auth = no


### PR DESCRIPTION
This pull make legacy auth work, using the new `legacyAuth` option in `py-sonic` 0.6.1 (see crustymonkey/py-sonic#17).